### PR TITLE
Fix invoice Printing

### DIFF
--- a/src/Dime/InvoiceBundle/Entity/InvoiceItem.php
+++ b/src/Dime/InvoiceBundle/Entity/InvoiceItem.php
@@ -256,7 +256,7 @@ class InvoiceItem extends Entity implements DimeEntityInterface
 	 */
 	public function getVat()
 	{
-		return $this->vat;
+		return $this->vat ? $this->vat : 0;
 	}
 
 	/**

--- a/src/Dime/InvoiceBundle/Resources/views/Invoice/print.pdf.twig
+++ b/src/Dime/InvoiceBundle/Resources/views/Invoice/print.pdf.twig
@@ -36,7 +36,7 @@
 			<div class="accountant">Sachbearbeiter: {{ invoice.user }}</div><br/>
 			{% endif %}
 			<br /><br />
-			<div class="invoiceIDKey">Rechnung {{invoice.project.name}}</div><br/>
+			<div class="invoiceIDKey">Rechnung {{invoice.project.name | default(invoice.name)}}</div><br/>
 
 			<table breakable="false" class="toptable">
 				<tr>


### PR DESCRIPTION
Fixes #82 

Flickt zudem einen Crash beim Drucken von Rechnungen, die ungültige Positionen enthalten.