### PR TITLE
146 symfony upgrade - zwischenstand in master mergen

### DIFF
--- a/app/Resources/FOSUserBundle/views/Security/login.html.twig
+++ b/app/Resources/FOSUserBundle/views/Security/login.html.twig
@@ -5,7 +5,7 @@
 		<div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
 	{% endif %}
 	<form action="{{ path("fos_user_security_check") }}" method="post">
-		<input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+		<input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}" />
 		<label for="username">{{ 'security.login.username'|trans }}</label>
 		<input type="text" id="username" name="_username" value="{{ last_username }}" required="required" />
 		<label for="password">{{ 'security.login.password'|trans }}</label>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -82,7 +82,7 @@ services:
     tags:
         - { name: doctrine.event_subscriber, connection: default }
     calls:
-        - [ setAnnotationReader, [ @annotation_reader ] ]
+        - [ setAnnotationReader, [ "@annotation_reader" ] ]
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -18,7 +18,7 @@ security:
             pattern:           ^/
             form_login:
                 provider:      fos_userbundle
-                csrf_provider: form.csrf_provider
+                csrf_provider: security.csrf.token_manager
                 use_forward:   true
             logout:            true
             anonymous:         true

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"stof/doctrine-extensions-bundle" : "^1.2",
 		"jms/serializer-bundle" : "~1.0",
 		"friendsofsymfony/rest-bundle" : "~1.7",
-		"friendsofsymfony/user-bundle" : "~2.0@dev",
+		"friendsofsymfony/user-bundle" : "^2.1",
 		"nelmio/api-doc-bundle" : "~2.9",
 		"knplabs/json-schema-bundle": "1.1.0",
 		"misd/phone-number-bundle" : "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,7 @@
 	"require-dev" : {
 		"h4cc/alice-fixtures-bundle" : "^0.5.1",
 		"phpunit/phpunit": "~5.7",
-		"squizlabs/php_codesniffer": "^3.2",
-		"symfony/phpunit-bridge": "^4.1"
+		"squizlabs/php_codesniffer": "^3.2"
 	},
 	"scripts" : {
 		"post-install-cmd" : [

--- a/composer.json
+++ b/composer.json
@@ -51,12 +51,14 @@
 		"sentry/sentry-symfony": "~1.0",
 		"nelmio/cors-bundle": "^1.5.0",
 		"mathiasverraes/money": "dev-master#941995d773d4f136e05e98c1d443cb627e761280",
-		"tbbc/money-bundle": "dev-master#f2b015f60ab0dd144f1a452abfaa87b2cc7764b6"
+		"tbbc/money-bundle": "dev-master#f2b015f60ab0dd144f1a452abfaa87b2cc7764b6",
+		"symfony/security-csrf": "~2.8"
 	},
 	"require-dev" : {
 		"h4cc/alice-fixtures-bundle" : "^0.5.1",
 		"phpunit/phpunit": "~5.7",
-		"squizlabs/php_codesniffer": "^3.2"
+		"squizlabs/php_codesniffer": "^3.2",
+		"symfony/phpunit-bridge": "^4.1"
 	},
 	"scripts" : {
 		"post-install-cmd" : [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4e0faf0e2f3dab1e35d47312777b2f0",
+    "content-hash": "9cd1474ec8bd6a4d8cc8702c5c1e2593",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1195,26 +1195,27 @@
         },
         {
             "name": "friendsofsymfony/user-bundle",
-            "version": "dev-master",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSUserBundle.git",
-                "reference": "315f837576d66f40e5e002d0caacfe1cfb5a58ba"
+                "reference": "1049935edd24ec305cc6cfde1875372fa9600446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSUserBundle/zipball/315f837576d66f40e5e002d0caacfe1cfb5a58ba",
-                "reference": "315f837576d66f40e5e002d0caacfe1cfb5a58ba",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSUserBundle/zipball/1049935edd24ec305cc6cfde1875372fa9600446",
+                "reference": "1049935edd24ec305cc6cfde1875372fa9600446",
                 "shasum": ""
             },
             "require": {
                 "paragonie/random_compat": "^1 || ^2",
                 "php": "^5.5.9 || ^7.0",
-                "symfony/form": "^2.7 || ^3.0",
-                "symfony/framework-bundle": "^2.7 || ^3.0",
-                "symfony/security-bundle": "^2.7 || ^3.0",
-                "symfony/templating": "^2.7 || ^3.0",
-                "symfony/twig-bundle": "^2.7 || ^3.0",
+                "symfony/form": "^2.8 || ^3.0 || ^4.0",
+                "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
+                "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0",
+                "symfony/templating": "^2.8 || ^3.0 || ^4.0",
+                "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0",
+                "symfony/validator": "^2.8 || ^3.0 || ^4.0",
                 "twig/twig": "^1.28 || ^2.0"
             },
             "conflict": {
@@ -1223,18 +1224,17 @@
             },
             "require-dev": {
                 "doctrine/doctrine-bundle": "^1.3",
-                "friendsofphp/php-cs-fixer": "^1.11",
-                "phpunit/phpunit": "~4.8|~5.0",
+                "friendsofphp/php-cs-fixer": "^2.2",
+                "phpunit/phpunit": "^4.8.35|^5.7.11|^6.5",
                 "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
-                "symfony/console": "^2.7 || ^3.0",
-                "symfony/phpunit-bridge": "^2.7 || ^3.0",
-                "symfony/validator": "^2.7 || ^3.0",
-                "symfony/yaml": "^2.7 || ^3.0"
+                "symfony/console": "^2.8 || ^3.0 || ^4.0",
+                "symfony/phpunit-bridge": "^2.8 || ^3.0 || ^4.0",
+                "symfony/yaml": "^2.8 || ^3.0 || ^4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1259,8 +1259,7 @@
                     "homepage": "https://github.com/friendsofsymfony/FOSUserBundle/contributors"
                 },
                 {
-                    "name": "Thibault Duplessis",
-                    "email": "thibault.duplessis@gmail.com"
+                    "name": "Thibault Duplessis"
                 }
             ],
             "description": "Symfony FOSUserBundle",
@@ -1268,7 +1267,7 @@
             "keywords": [
                 "User management"
             ],
-            "time": "2017-08-11T10:26:53+00:00"
+            "time": "2018-03-08T08:59:27+00:00"
         },
         {
             "name": "gedmo/doctrine-extensions",
@@ -6350,72 +6349,6 @@
             "time": "2018-02-20T21:35:23+00:00"
         },
         {
-            "name": "symfony/phpunit-bridge",
-            "version": "v4.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "c7f28cbf2df4e9deed7fc376ca4f146eaa5afc8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/c7f28cbf2df4e9deed7fc376ca4f146eaa5afc8a",
-                "reference": "c7f28cbf2df4e9deed7fc376ca4f146eaa5afc8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "suggest": {
-                "ext-zip": "Zip support is required when using bin/simple-phpunit",
-                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
-            },
-            "bin": [
-                "bin/simple-phpunit"
-            ],
-            "type": "symfony-bridge",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.1-dev"
-                },
-                "thanks": {
-                    "name": "phpunit/phpunit",
-                    "url": "https://github.com/sebastianbergmann/phpunit"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Bridge\\PhpUnit\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony PHPUnit Bridge",
-            "homepage": "https://symfony.com",
-            "time": "2018-06-11T12:56:28+00:00"
-        },
-        {
             "name": "webmozart/assert",
             "version": "1.3.0",
             "source": {
@@ -6469,7 +6402,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "friendsofsymfony/user-bundle": 20,
         "doctrine/doctrine-migrations-bundle": 20,
         "psliwa/pdf-bundle": 20,
         "mathiasverraes/money": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "715897b7042b86f278ef6e41407eb18b",
+    "content-hash": "b4e0faf0e2f3dab1e35d47312777b2f0",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -3484,6 +3484,7 @@
                 "compression",
                 "minification"
             ],
+            "abandoned": "symfony/webpack-encore-pack",
             "time": "2017-07-14T07:26:46+00:00"
         },
         {
@@ -3598,6 +3599,61 @@
                 "shim"
             ],
             "time": "2017-07-05T15:09:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -4119,16 +4175,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.8.32",
+            "version": "v2.8.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "0efa80d0a01f60e28ae5800c94d6288239cefefe"
+                "reference": "0084ec5bb6614688f547ef80bf1ef8a900c4e350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/0efa80d0a01f60e28ae5800c94d6288239cefefe",
-                "reference": "0efa80d0a01f60e28ae5800c94d6288239cefefe",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/0084ec5bb6614688f547ef80bf1ef8a900c4e350",
+                "reference": "0084ec5bb6614688f547ef80bf1ef8a900c4e350",
                 "shasum": ""
             },
             "require": {
@@ -4137,6 +4193,7 @@
                 "php": ">=5.3.9",
                 "psr/log": "~1.0",
                 "symfony/polyfill-apcu": "~1.1",
+                "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php54": "~1.0",
@@ -4254,7 +4311,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-12-04T22:02:29+00:00"
+            "time": "2018-06-25T12:02:18+00:00"
         },
         {
             "name": "tbbc/money-bundle",
@@ -6291,6 +6348,72 @@
                 "standards"
             ],
             "time": "2018-02-20T21:35:23+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "c7f28cbf2df4e9deed7fc376ca4f146eaa5afc8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/c7f28cbf2df4e9deed7fc376ca4f146eaa5afc8a",
+                "reference": "c7f28cbf2df4e9deed7fc376ca4f146eaa5afc8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "ext-zip": "Zip support is required when using bin/simple-phpunit",
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2018-06-11T12:56:28+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Dime/EmployeeBundle/Form/Type/EmployeeFormType.php
+++ b/src/Dime/EmployeeBundle/Form/Type/EmployeeFormType.php
@@ -7,11 +7,11 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EmployeeFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -35,10 +35,5 @@ class EmployeeFormType extends AbstractType
             ->add('extendTimetrack')
             ->add('workingPeriods', EntityType::class, array('class' => 'DimeEmployeeBundle:Period', 'multiple' => true))
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_employeebundle_employeeformtype';
     }
 }

--- a/src/Dime/EmployeeBundle/Form/Type/HolidayFormType.php
+++ b/src/Dime/EmployeeBundle/Form/Type/HolidayFormType.php
@@ -12,11 +12,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HolidayFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -33,10 +33,5 @@ class HolidayFormType extends AbstractType
             ->add('date', DateTimeType::class, array('required' => true, 'widget' => 'single_text', 'with_seconds' => true))
             ->add('duration', TextType::class)
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_employeebundle_holidayformtype';
     }
 }

--- a/src/Dime/EmployeeBundle/Form/Type/PeriodFormType.php
+++ b/src/Dime/EmployeeBundle/Form/Type/PeriodFormType.php
@@ -12,11 +12,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PeriodFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -39,10 +39,5 @@ class PeriodFormType extends AbstractType
             ->add('lastYearHolidayBalance')
             ->add('yearlyEmployeeVacationBudget', IntegerType::class, ['required' => true])
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_employeebundle_periodformtype';
     }
 }

--- a/src/Dime/EmployeeBundle/Resources/config/forms.yml
+++ b/src/Dime/EmployeeBundle/Resources/config/forms.yml
@@ -1,12 +1,12 @@
 services:
     dime.employee.form.type:
         class: Dime\EmployeeBundle\Form\Type\EmployeeFormType
-        tags: [{ name: form.type, alias: dime_employeebundle_employeeformtype }]
+        tags: [{ name: form.type }]
 
     dime.period.form.type:
         class: Dime\EmployeeBundle\Form\Type\PeriodFormType
-        tags: [{ name: form.type, alias: dime_employeebundle_periodformtype }]
+        tags: [{ name: form.type }]
 
     dime.holiday.form.type:
         class: Dime\EmployeeBundle\Form\Type\HolidayFormType
-        tags: [{ name: form.type, alias: dime_employeebundle_holidayformtype }]
+        tags: [{ name: form.type }]

--- a/src/Dime/EmployeeBundle/Resources/config/services.yml
+++ b/src/Dime/EmployeeBundle/Resources/config/services.yml
@@ -4,15 +4,15 @@ parameters:
 services:
     dime.employee.handler:
         class: "Dime\\TimetrackerBundle\\Handler\\UserHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\EmployeeBundle\Entity\Employee", "@service_container", "@fos_user.user_manager", "em", "dime_employeebundle_employeeformtype" ]
+        arguments: [ "@doctrine.orm.entity_manager", "Dime\\EmployeeBundle\\Entity\\Employee", "@service_container", "@fos_user.user_manager", "em", "dime_employeebundle_employeeformtype" ]
 
     dime.period.handler:
-        class: "Dime\TimetrackerBundle\Handler\\PeriodHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\EmployeeBundle\Entity\\Period",  "@service_container", "p", "dime_employeebundle_periodformtype"]
+        class: "Dime\\TimetrackerBundle\\Handler\\PeriodHandler"
+        arguments: [ "@doctrine.orm.entity_manager", "Dime\\EmployeeBundle\\Entity\\Period",  "@service_container", "p", "dime_employeebundle_periodformtype"]
 
     dime.holiday.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\EmployeeBundle\Entity\Holiday",  "@service_container", "h", "dime_employeebundle_holidayformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", "Dime\\EmployeeBundle\\Entity\Holiday",  "@service_container", "h", "dime_employeebundle_holidayformtype"]
 
     dime.persist.event.timeslice:
          class: Dime\EmployeeBundle\EventListener\TimeslicePersistSubscriber

--- a/src/Dime/EmployeeBundle/Resources/config/services.yml
+++ b/src/Dime/EmployeeBundle/Resources/config/services.yml
@@ -1,35 +1,35 @@
 parameters:
-    generic_handler: "Dime\\EmployeeBundle\\Handler\\GenericHandler"
+    generic_handler: Dime\EmployeeBundle\Handler\GenericHandler
 
 services:
     dime.employee.handler:
-        class: "Dime\\TimetrackerBundle\\Handler\\UserHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\\EmployeeBundle\\Entity\\Employee", "@service_container", "@fos_user.user_manager", "em", "dime_employeebundle_employeeformtype" ]
+        class: Dime\TimetrackerBundle\Handler\UserHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\EmployeeBundle\Entity\Employee, "@service_container", "@fos_user.user_manager", "em", Dime\EmployeeBundle\Form\Type\EmployeeFormType]
 
     dime.period.handler:
-        class: "Dime\\TimetrackerBundle\\Handler\\PeriodHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\\EmployeeBundle\\Entity\\Period",  "@service_container", "p", "dime_employeebundle_periodformtype"]
+        class: Dime\TimetrackerBundle\Handler\PeriodHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\EmployeeBundle\Entity\Period,  "@service_container", "p", Dime\EmployeeBundle\Form\Type\PeriodFormType]
 
     dime.holiday.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\\EmployeeBundle\\Entity\Holiday",  "@service_container", "h", "dime_employeebundle_holidayformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\EmployeeBundle\Entity\Holiday,  "@service_container", "h", Dime\EmployeeBundle\Form\Type\HolidayFormType]
 
     dime.persist.event.timeslice:
          class: Dime\EmployeeBundle\EventListener\TimeslicePersistSubscriber
          calls:
-            - [ setContainer,  [@service_container] ]
+            - [ setContainer,  ["@service_container"] ]
          tags:
             - { name: kernel.event_subscriber }
 
     dime.persist.event.period:
          class: Dime\EmployeeBundle\EventListener\PeriodPersistSubscriber
          calls:
-            - [ setContainer,  [@service_container] ]
+            - [ setContainer,  ["@service_container"] ]
          tags:
             - { name: kernel.event_subscriber }
     dime.persist.event.holiday:
          class: Dime\EmployeeBundle\EventListener\HolidayPersistSubscriber
          calls:
-            - [ setContainer,  [@service_container] ]
+            - [ setContainer,  ["@service_container"] ]
          tags:
             - { name: kernel.event_subscriber }

--- a/src/Dime/InvoiceBundle/Form/Type/CostGroupFormType.php
+++ b/src/Dime/InvoiceBundle/Form/Type/CostGroupFormType.php
@@ -9,7 +9,7 @@ namespace Dime\InvoiceBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CostgroupFormType extends AbstractType
 {
@@ -21,22 +21,12 @@ class CostgroupFormType extends AbstractType
         ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Dime\InvoiceBundle\Entity\Costgroup',
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ));
-    }
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'dime_invoicebundle_costgroupformtype';
     }
 }

--- a/src/Dime/InvoiceBundle/Form/Type/InvoiceCostgroupFormType.php
+++ b/src/Dime/InvoiceBundle/Form/Type/InvoiceCostgroupFormType.php
@@ -3,7 +3,7 @@ namespace Dime\InvoiceBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class InvoiceCostgroupFormType extends AbstractType
 {
@@ -16,23 +16,12 @@ class InvoiceCostgroupFormType extends AbstractType
             ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Dime\InvoiceBundle\Entity\InvoiceCostgroup',
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ));
-    }
-
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'dime_invoicebundle_invoicecostgroupformtype';
     }
 }

--- a/src/Dime/InvoiceBundle/Form/Type/InvoiceDiscountFormType.php
+++ b/src/Dime/InvoiceBundle/Form/Type/InvoiceDiscountFormType.php
@@ -9,7 +9,7 @@ namespace Dime\InvoiceBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class InvoiceDiscountFormType extends AbstractType
 {
@@ -25,23 +25,12 @@ class InvoiceDiscountFormType extends AbstractType
             ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Dime\InvoiceBundle\Entity\InvoiceDiscount',
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ));
-    }
-
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'dime_invoicebundle_invoicediscountformtype';
     }
 }

--- a/src/Dime/InvoiceBundle/Form/Type/InvoiceFormType.php
+++ b/src/Dime/InvoiceBundle/Form/Type/InvoiceFormType.php
@@ -11,7 +11,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class InvoiceFormType extends AbstractType
@@ -34,23 +34,12 @@ class InvoiceFormType extends AbstractType
         ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Dime\InvoiceBundle\Entity\Invoice',
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ));
-    }
-
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'dime_invoicebundle_invoiceformtype';
     }
 }

--- a/src/Dime/InvoiceBundle/Form/Type/InvoiceItemFormType.php
+++ b/src/Dime/InvoiceBundle/Form/Type/InvoiceItemFormType.php
@@ -11,7 +11,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class InvoiceItemFormType extends AbstractType
@@ -30,23 +30,12 @@ class InvoiceItemFormType extends AbstractType
         ;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Dime\InvoiceBundle\Entity\InvoiceItem',
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ));
-    }
-
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'dime_invoicebundle_invoiceitemformtype';
     }
 }

--- a/src/Dime/InvoiceBundle/Resources/config/forms.yml
+++ b/src/Dime/InvoiceBundle/Resources/config/forms.yml
@@ -1,20 +1,20 @@
 services:
     dime_invoicebundle_invoicediscountformtype:
         class: Dime\InvoiceBundle\Form\Type\InvoiceDiscountFormType
-        tags: [{ name: "form.type", alias: "dime_invoicebundle_invoicediscountformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.invoicebundle.invoice.formtype:
         class: Dime\InvoiceBundle\Form\Type\InvoiceFormType
-        tags: [{ name: "form.type", alias: "dime_invoicebundle_invoiceformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.invoicebundle.invoiceitem.formtype:
             class: Dime\InvoiceBundle\Form\Type\InvoiceItemFormType
-            tags: [{ name: "form.type", alias: "dime_invoicebundle_invoiceitemformtype" }]
+            tags: [{ name: "form.type" }]
 
     dime.invoicebundle.costgroup.formtype:
             class: Dime\InvoiceBundle\Form\Type\CostgroupFormType
-            tags: [{ name: "form.type", alias: "dime_invoicebundle_costgroupformtype" }]
+            tags: [{ name: "form.type" }]
 
     dime.invoicebundle.invoicecostgroup.formtype:
             class: Dime\InvoiceBundle\Form\Type\InvoiceCostgroupFormType
-            tags: [{ name: "form.type", alias: "dime_invoicebundle_invoicecostgroupformtype" }]
+            tags: [{ name: "form.type" }]

--- a/src/Dime/InvoiceBundle/Resources/config/services.yml
+++ b/src/Dime/InvoiceBundle/Resources/config/services.yml
@@ -1,35 +1,35 @@
 parameters:
-    generic_handler: "Dime\TimetrackerBundle\Handler\GenericHandler"
+    generic_handler: Dime\TimetrackerBundle\Handler\GenericHandler
 
 services:
     dime.invoice.handler:
-        class: "Dime\InvoiceBundle\Handler\InvoiceHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\InvoiceBundle\Entity\Invoice", "@service_container", "inv", "dime_invoicebundle_invoiceformtype" ]
+        class: Dime\InvoiceBundle\Handler\InvoiceHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\InvoiceBundle\Entity\Invoice, "@service_container", "inv", Dime\InvoiceBundle\Form\Type\InvoiceFormType]
 
     dime.invoicediscount.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\InvoiceBundle\Entity\InvoiceDiscount", "@service_container", "invd", "dime_invoicebundle_invoicediscountformtype" ]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\InvoiceBundle\Entity\InvoiceDiscount, "@service_container", "invd", Dime\InvoiceBundle\Form\Type\InvoiceDiscountFormType]
 
     dime.invoicecostgroup.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\InvoiceBundle\Entity\InvoiceCostgroup", "@service_container", "invc", "dime_invoicebundle_invoicecostgroupformtype" ]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\InvoiceBundle\Entity\InvoiceCostgroup, "@service_container", "invc", Dime\InvoiceBundle\Form\Type\InvoiceCostgroupFormType]
 
     dime.invoiceitem.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\InvoiceBundle\Entity\InvoiceItem", "@service_container", "invt", "dime_invoicebundle_invoiceitemformtype" ]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\InvoiceBundle\Entity\InvoiceItem, "@service_container", "invt", Dime\InvoiceBundle\Form\Type\InvoiceItemFormType]
 
     dime.costgroup.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\InvoiceBundle\Entity\Costgroup", "@service_container", "invt", "dime_invoicebundle_costgroupformtype" ]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\InvoiceBundle\Entity\Costgroup, "@service_container", "invt", Dime\InvoiceBundle\Form\Type\CostgroupFormType]
 
 
     dime.invoice.configreader:
         class: Dime\InvoiceBundle\Service\InvoiceConfigurationValueReader
         calls:
-            - [ setContainer,  [@service_container] ]
+            - [ setContainer,  ["@service_container"] ]
 
     twig.extension.invoiceconfig:
         class: Dime\InvoiceBundle\Extensions\InvoiceConfigurationExtension
-        arguments: [@dime.invoice.configreader]
+        arguments: ["@dime.invoice.configreader"]
         tags:
             - { name: twig.extension }

--- a/src/Dime/InvoiceBundle/Tests/Controller/InvoiceControllerTest.php
+++ b/src/Dime/InvoiceBundle/Tests/Controller/InvoiceControllerTest.php
@@ -21,6 +21,7 @@ class InvoiceControllerTest extends DimeTestCase
 
         /* check existing service */
         $response = $this->jsonRequest('GET', $this->api_prefix.'/invoices/1');
+        $this->assertEquals(200, $response->getStatusCode());
 
         // convert json to array
         $data = json_decode($response->getContent(), true);

--- a/src/Dime/OfferBundle/Form/Type/OfferDiscountFormType.php
+++ b/src/Dime/OfferBundle/Form/Type/OfferDiscountFormType.php
@@ -4,11 +4,11 @@ namespace Dime\OfferBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class OfferDiscountFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -29,10 +29,5 @@ class OfferDiscountFormType extends AbstractType
             ->add('user')
             ->add('offer')
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_offerbundle_offerdiscountformtype';
     }
 }

--- a/src/Dime/OfferBundle/Form/Type/OfferFormType.php
+++ b/src/Dime/OfferBundle/Form/Type/OfferFormType.php
@@ -6,12 +6,12 @@ use Swo\CommonsBundle\Form\Type\AddressFormType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class OfferFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -39,10 +39,5 @@ class OfferFormType extends AbstractType
             ->add('address', AddressFormType::class)
             ->add('validTo', DateTimeType::class, array('required' => false, 'widget' => 'single_text', 'with_seconds' => false))
             ->add('offerPositions');
-    }
-
-    public function getName()
-    {
-        return 'dime_offerbundle_offerformtype';
     }
 }

--- a/src/Dime/OfferBundle/Form/Type/OfferPositionFormType.php
+++ b/src/Dime/OfferBundle/Form/Type/OfferPositionFormType.php
@@ -4,12 +4,12 @@ namespace Dime\OfferBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class OfferPositionFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -32,10 +32,5 @@ class OfferPositionFormType extends AbstractType
             ->add('vat')
             ->add('user')
             ->add('service');
-    }
-
-    public function getName()
-    {
-        return 'dime_offerbundle_offerpositionformtype';
     }
 }

--- a/src/Dime/OfferBundle/Form/Type/OfferStatusUCFormType.php
+++ b/src/Dime/OfferBundle/Form/Type/OfferStatusUCFormType.php
@@ -4,11 +4,11 @@ namespace Dime\OfferBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class OfferStatusUCFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -25,10 +25,5 @@ class OfferStatusUCFormType extends AbstractType
             ->add('text')
             ->add('user')
             ->add('active');
-    }
-
-    public function getName()
-    {
-        return 'dime_offerbundle_offerstatusucformtype';
     }
 }

--- a/src/Dime/OfferBundle/Resources/config/forms.yml
+++ b/src/Dime/OfferBundle/Resources/config/forms.yml
@@ -1,16 +1,16 @@
 services:
     dime.offer.form.type:
         class: Dime\OfferBundle\Form\Type\OfferFormType
-        tags: [{ name: form.type, alias: dime_offerbundle_offerformtype }]
+        tags: [{ name: form.type }]
 
     dime.offerposition.form.type:
         class: Dime\OfferBundle\Form\Type\OfferPositionFormType
-        tags: [{ name: form.type, alias: dime_offerbundle_offerpositionformtype }]
+        tags: [{ name: form.type }]
 
     dime.offerstatusuc.form.type:
         class: Dime\OfferBundle\Form\Type\OfferStatusUCFormType
-        tags: [{ name: form.type, alias: dime_offerbundle_offerstatusucformtype }]
+        tags: [{ name: form.type }]
 
     dime.offerdiscount.form.type:
         class: Dime\OfferBundle\Form\Type\OfferDiscountFormType
-        tags: [{ name: form.type, alias: dime_offerbundle_offerdiscountformtype }]
+        tags: [{ name: form.type }]

--- a/src/Dime/OfferBundle/Resources/config/services.yml
+++ b/src/Dime/OfferBundle/Resources/config/services.yml
@@ -1,19 +1,19 @@
 parameters:
-    generic_handler: "Dime\TimetrackerBundle\Handler\GenericHandler"
+    generic_handler: Dime\TimetrackerBundle\Handler\GenericHandler
 
 services:
     dime.offer.handler:
-        class: "Dime\OfferBundle\Handler\OfferHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\OfferBundle\Entity\Offer", "@service_container", "o", "dime_offerbundle_offerformtype"]
+        class: Dime\OfferBundle\Handler\OfferHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\OfferBundle\Entity\Offer, "@service_container", "o", Dime\OfferBundle\Form\Type\OfferFormType]
         
     dime.offerposition.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\OfferBundle\Entity\OfferPosition", "@service_container", "op", "dime_offerbundle_offerpositionformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\OfferBundle\Entity\OfferPosition, "@service_container", "op", Dime\OfferBundle\Form\Type\OfferPositionFormType]
 
     dime.offerstatusuc.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\OfferBundle\Entity\OfferStatusUC", "@service_container", "os", "dime_offerbundle_offerstatusucformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\OfferBundle\Entity\OfferStatusUC, "@service_container", "os", Dime\OfferBundle\Form\Type\OfferStatusUCFormType]
 
     dime.offerdiscount.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\OfferBundle\Entity\OfferDiscount", "@service_container", "od", "dime_offerbundle_offerdiscountformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\OfferBundle\Entity\OfferDiscount, "@service_container", "od", Dime\OfferBundle\Form\Type\OfferDiscountFormType]

--- a/src/Dime/PrintingBundle/Resources/config/services.yml
+++ b/src/Dime/PrintingBundle/Resources/config/services.yml
@@ -2,7 +2,7 @@ parameters:
 
 services:
     dime.print.pdf:
-        class: 'Dime\PrintingBundle\Service\PrintService'
+        class: Dime\PrintingBundle\Service\PrintService
         arguments: [ '@templating', '@ps_pdf.facade_builder', '@ps_pdf.cache' ]
 
     charbox.twig_extension:

--- a/src/Dime/ReportBundle/Resources/config/services.yml
+++ b/src/Dime/ReportBundle/Resources/config/services.yml
@@ -1,4 +1,4 @@
 services:
     dime.report.handler:
         class: Dime\ReportBundle\Handler\ReportHandler
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Timeslice",  "@service_container", "tim", "dime_timetrackerbundle_timesliceformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Timeslice,  "@service_container", "tim", "dime_timetrackerbundle_timesliceformtype"]

--- a/src/Dime/TimetrackerBundle/Controller/ActivitiesController.php
+++ b/src/Dime/TimetrackerBundle/Controller/ActivitiesController.php
@@ -17,8 +17,6 @@ class ActivitiesController extends DimeController
 {
     private $handlerSerivce = 'dime.activity.handler';
 
-    private $formType = 'dime_timetrackerbundle_activityformtype';
-
     /**
      * List all Entities.
      *

--- a/src/Dime/TimetrackerBundle/Controller/DimeController.php
+++ b/src/Dime/TimetrackerBundle/Controller/DimeController.php
@@ -19,7 +19,7 @@ class DimeController extends FOSRestController
      */
     protected function getCurrentUser()
     {
-        $user = $this->container->get('security.context')->getToken()->getUser();
+        $user = $this->container->get('security.token_storage')->getToken()->getUser();
         if (!is_object($user) || !$user instanceof UserInterface) {
             throw new AccessDeniedException(
                 'This user does not have access to this section.'

--- a/src/Dime/TimetrackerBundle/Form/Type/ActivityFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/ActivityFormType.php
@@ -5,12 +5,12 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class ActivityFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -38,10 +38,5 @@ class ActivityFormType extends AbstractType
             ->add('tags', EntityType::class, array('class' => 'DimeTimetrackerBundle:Tag', 'multiple' => true))
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'))
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_activityformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/CustomerFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/CustomerFormType.php
@@ -7,11 +7,11 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomerFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -43,10 +43,5 @@ class CustomerFormType extends AbstractType
             ->add('phones', CollectionType::class, array('type' => 'swo_commons_phoneformtype'))
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'))
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_customerformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/ProjectCategoryFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/ProjectCategoryFormType.php
@@ -4,11 +4,11 @@ namespace Dime\TimetrackerBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProjectCategoryFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -25,10 +25,5 @@ class ProjectCategoryFormType extends AbstractType
             ->add('id')
             ->add('name')
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_projectcategoryformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/ProjectCommentFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/ProjectCommentFormType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProjectCommentFormType extends AbstractType
 {
@@ -28,20 +28,12 @@ class ProjectCommentFormType extends AbstractType
     /**
      * @inheritDoc
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'data_class' => ProjectComment::class,
             'csrf_protection' => false,
             'allow_extra_fields' => true,
         ]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getName()
-    {
-        return 'dime_invoicebundle_projectcommentformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/ProjectFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/ProjectFormType.php
@@ -7,12 +7,12 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class ProjectFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -45,10 +45,5 @@ class ProjectFormType extends AbstractType
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'))
             ->add('projectCategory', EntityType::class, array('class' => 'DimeTimetrackerBundle:ProjectCategory'))
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_projectformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/RateFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/RateFormType.php
@@ -5,12 +5,12 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Tbbc\MoneyBundle\Form\Type\SimpleMoneyType;
 
 class RateFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -30,10 +30,5 @@ class RateFormType extends AbstractType
             ->add('rateUnit')
             ->add('rateValue', SimpleMoneyType::class)
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'));
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_rateformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/RateGroupFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/RateGroupFormType.php
@@ -5,11 +5,11 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RateGroupFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -26,10 +26,5 @@ class RateGroupFormType extends AbstractType
             ->add('name')
             ->add('description')
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'));
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_rategroupformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/RateUnitTypeFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/RateUnitTypeFormType.php
@@ -5,11 +5,11 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RateUnitTypeFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -31,10 +31,5 @@ class RateUnitTypeFormType extends AbstractType
             ->add('roundMode', IntegerType::class, array('empty_data' => strval(PHP_ROUND_HALF_UP)))
             ->add('symbol')
             ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_rateunittypeformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/ServiceFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/ServiceFormType.php
@@ -6,11 +6,11 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ServiceFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -34,10 +34,5 @@ class ServiceFormType extends AbstractType
             ->add('tags', EntityType::class, array('class' => 'DimeTimetrackerBundle:Tag', 'multiple' => true))
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'))
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_serviceformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/SettingFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/SettingFormType.php
@@ -5,11 +5,11 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SettingFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -27,10 +27,5 @@ class SettingFormType extends AbstractType
             ->add('name')
             ->add('value')
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'));
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_settingformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/TagFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/TagFormType.php
@@ -4,7 +4,7 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TagFormType extends AbstractType
 {
@@ -25,16 +25,7 @@ class TagFormType extends AbstractType
      * (non-PHPdoc)
      * @see \Symfony\Component\Form\AbstractType::setDefaultOptions()
      */
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_tagformtype';
-    }
-
-    /*
-     * (non-PHPdoc)
-     * @see \Symfony\Component\Form\AbstractType::setDefaultOptions()
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/src/Dime/TimetrackerBundle/Form/Type/TimesliceFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/TimesliceFormType.php
@@ -7,11 +7,11 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TimesliceFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -33,10 +33,5 @@ class TimesliceFormType extends AbstractType
             ->add('tags', EntityType::class, array('class' => 'DimeTimetrackerBundle:Tag', 'multiple' => true, 'required' =>false))
             ->add('user', EntityType::class, array('class' => 'DimeTimetrackerBundle:User'))
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_timesliceformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Form/Type/UserFormType.php
+++ b/src/Dime/TimetrackerBundle/Form/Type/UserFormType.php
@@ -5,11 +5,11 @@ namespace Dime\TimetrackerBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserFormType extends AbstractType
 {
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -31,10 +31,5 @@ class UserFormType extends AbstractType
             ->add('enabled')
             ->add('employeeholiday')
         ;
-    }
-
-    public function getName()
-    {
-        return 'dime_timetrackerbundle_userformtype';
     }
 }

--- a/src/Dime/TimetrackerBundle/Handler/AbstractHandler.php
+++ b/src/Dime/TimetrackerBundle/Handler/AbstractHandler.php
@@ -34,7 +34,7 @@ abstract class AbstractHandler
         $this->entityClass = $entityClass;
         $this->repository = $this->om->getRepository($this->entityClass);
         $this->formFactory = $container->get('form.factory');
-        $this->secContext = $container->get('security.context');
+        $this->secContext = $container->get('security.token_storage');
         $this->eventDispatcher = $container->get('event_dispatcher');
         $this->container = $container;
         $this->alias = $alias;

--- a/src/Dime/TimetrackerBundle/Resources/config/config.yml
+++ b/src/Dime/TimetrackerBundle/Resources/config/config.yml
@@ -8,7 +8,7 @@ stof_doctrine_extensions:
 fos_user:
     db_driver: orm
     firewall_name: main
-    user_class: "Dime\EmployeeBundle\Entity\Employee"
+    user_class: Dime\EmployeeBundle\Entity\Employee
     from_email:
         address: "%sender_mail%"
         sender_name: DimeERP

--- a/src/Dime/TimetrackerBundle/Resources/config/forms.yml
+++ b/src/Dime/TimetrackerBundle/Resources/config/forms.yml
@@ -1,52 +1,52 @@
 services:
     dime.user.form.type:
         class: Dime\TimetrackerBundle\Form\Type\UserFormType
-        tags: [{ name: form.type, alias: dime_timetrackerbundle_userformtype }]
+        tags: [{ name: form.type }]
 
     dime.timeslice.form.type:
         class: Dime\TimetrackerBundle\Form\Type\TimesliceFormType
-        tags: [ { name: form.type, alias: dime_timetrackerbundle_timesliceformtype }]
+        tags: [ { name: form.type }]
 
     dime.tag.form.type:
         class: Dime\TimetrackerBundle\Form\Type\TagFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_tagformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.setting.form.type:
         class: Dime\TimetrackerBundle\Form\Type\SettingFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_settingformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.service.form.type:
         class: Dime\TimetrackerBundle\Form\Type\ServiceFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_serviceformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.project.form.type:
         class: Dime\TimetrackerBundle\Form\Type\ProjectFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_projectformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.customer.form.type:
         class: Dime\TimetrackerBundle\Form\Type\CustomerFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_customerformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.activity.form.type:
         class: Dime\TimetrackerBundle\Form\Type\ActivityFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_activityformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.rategroup.form.type:
         class: Dime\TimetrackerBundle\Form\Type\RateGroupFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_rategroupformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.rate.form.type:
         class: Dime\TimetrackerBundle\Form\Type\RateFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_rateformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.rategunittype.form.type:
         class: Dime\TimetrackerBundle\Form\Type\RateUnitTypeFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_rateunittypeformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.projectcategory.form.type:
         class: Dime\TimetrackerBundle\Form\Type\ProjectCategoryFormType
-        tags: [{ name: "form.type", alias: "dime_timetrackerbundle_projectcategoryformtype" }]
+        tags: [{ name: "form.type" }]
 
     dime.projectcomment.form.type:
         class: Dime\TimetrackerBundle\Form\Type\ProjectCommentFormType
-        tags: [{ name: "form.type", alias: "dime_invoicebundle_projectcommentformtype" }]
+        tags: [{ name: "form.type" }]

--- a/src/Dime/TimetrackerBundle/Resources/config/services.yml
+++ b/src/Dime/TimetrackerBundle/Resources/config/services.yml
@@ -1,58 +1,58 @@
 parameters:
-    generic_handler: "Dime\\TimetrackerBundle\\Handler\\GenericHandler"
+    generic_handler: Dime\TimetrackerBundle\Handler\GenericHandler
 
 services:
     dime.user.handler:
-        class: "Dime\\TimetrackerBundle\\Handler\\UserHandler"
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\\User", "@service_container", "@fos_user.user_manager", "us", "dime_timetrackerbundle_userformtype" ]
+        class: Dime\TimetrackerBundle\Handler\UserHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\User, "@service_container", "@fos_user.user_manager", "us", Dime\TimetrackerBundle\Form\Type\UserFormType]
 
     dime.timeslice.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Timeslice",  "@service_container", "ti", "dime_timetrackerbundle_timesliceformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Timeslice,  "@service_container", "ti", Dime\TimetrackerBundle\Form\Type\TimesliceFormType]
 
     dime.tag.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Tag",  "@service_container", "t", "dime_timetrackerbundle_tagformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Tag,  "@service_container", "t", Dime\TimetrackerBundle\Form\Type\TagFormType]
 
     dime.setting.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Setting",  "@service_container", "se", "dime_timetrackerbundle_settingformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Setting,  "@service_container", "se", Dime\TimetrackerBundle\Form\Type\SettingFormType]
 
     dime.service.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Service",  "@service_container", "s", "dime_timetrackerbundle_serviceformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Service,  "@service_container", "s", Dime\TimetrackerBundle\Form\Type\ServiceFormType]
 
     dime.project.handler:
-        class: 'Dime\TimetrackerBundle\Handler\ProjectHandler'
-        arguments: [ "@doctrine.orm.entity_manager", 'Dime\TimetrackerBundle\Entity\Project',  "@service_container", "p", "dime_timetrackerbundle_projectformtype"]
+        class: Dime\TimetrackerBundle\Handler\ProjectHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Project,  "@service_container", "p", Dime\TimetrackerBundle\Form\Type\ProjectFormType]
 
     dime.customer.handler:
-        class: 'Dime\TimetrackerBundle\Handler\CustomerHandler'
-        arguments: [ "@doctrine.orm.entity_manager", 'Dime\TimetrackerBundle\Entity\Customer',  "@service_container", "c", "dime_timetrackerbundle_customerformtype"]
+        class: Dime\TimetrackerBundle\Handler\CustomerHandler
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Customer,  "@service_container", "c", Dime\TimetrackerBundle\Form\Type\CustomerFormType]
 
     dime.activity.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Activity",  "@service_container", "a", "dime_timetrackerbundle_activityformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Activity,  "@service_container", "a", Dime\TimetrackerBundle\Form\Type\ActivityFormType]
 
     dime.rategroup.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\RateGroup",  "@service_container", "rg", "dime_timetrackerbundle_rategroupformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\RateGroup,  "@service_container", "rg", Dime\TimetrackerBundle\Form\Type\RateGroupFormType]
 
     dime.rate.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\Rate",  "@service_container", "r", "dime_timetrackerbundle_rateformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\Rate,  "@service_container", "r", Dime\TimetrackerBundle\Form\Type\RateFormType]
 
     dime.rateunittype.handler:
          class: %generic_handler%
-         arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\RateUnitType",  "@service_container", "rt", "dime_timetrackerbundle_rateunittypeformtype"]
+         arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\RateUnitType,  "@service_container", "rt", Dime\TimetrackerBundle\Form\Type\RateUnitTypeFormType]
 
     dime.projectcategory.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\\ProjectCategory",  "@service_container", "pc", "dime_timetrackerbundle_projectcategoryformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\ProjectCategory,  "@service_container", "pc", Dime\TimetrackerBundle\Form\Type\ProjectCategoryFormType]
 
     dime.projectcomment.handler:
         class: %generic_handler%
-        arguments: [ "@doctrine.orm.entity_manager", "Dime\TimetrackerBundle\Entity\\ProjectComment",  "@service_container", "pcom", "dime_invoicebundle_projectcommentformtype"]
+        arguments: [ "@doctrine.orm.entity_manager", Dime\TimetrackerBundle\Entity\ProjectComment,  "@service_container", "pcom", Dime\TimetrackerBundle\Form\Type\ProjectCommentFormType]
 
     dime.alice.processor:
         class: Dime\TimetrackerBundle\DataFixtures\Alice\Processor

--- a/src/Dime/TimetrackerBundle/Tests/Controller/DimeTestCase.php
+++ b/src/Dime/TimetrackerBundle/Tests/Controller/DimeTestCase.php
@@ -95,7 +95,7 @@ class DimeTestCase extends WebTestCase
             $loginManager->loginUser($firewallName, $user);
 
             // save the login token into the session and put it in a cookie
-            $container->get('session')->set('_security_' . $firewallName, serialize($container->get('security.context')->getToken()));
+            $container->get('session')->set('_security_' . $firewallName, serialize($container->get('security.token_storage')->getToken()));
             $container->get('session')->save();
             $this->client->getCookieJar()->set(new Cookie($session->getName(), $session->getId()));
         }

--- a/src/Swo/CommonsBundle/Form/Type/AddressFormType.php
+++ b/src/Swo/CommonsBundle/Form/Type/AddressFormType.php
@@ -4,7 +4,7 @@ namespace Swo\CommonsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AddressFormType extends AbstractType
 {
@@ -17,12 +17,7 @@ class AddressFormType extends AbstractType
             ->add('country');
     }
 
-    public function getName()
-    {
-        return 'swo_commons_addressformtype';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Swo\CommonsBundle\Entity\Address',

--- a/src/Swo/CommonsBundle/Form/Type/AddressFormType.php
+++ b/src/Swo/CommonsBundle/Form/Type/AddressFormType.php
@@ -21,7 +21,6 @@ class AddressFormType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Swo\CommonsBundle\Entity\Address',
-            'cascade_validation' => true,
             'translation_domain' => 'SwoCommonsBundle'
         ));
     }

--- a/src/Swo/CommonsBundle/Form/Type/PhoneFormType.php
+++ b/src/Swo/CommonsBundle/Form/Type/PhoneFormType.php
@@ -9,7 +9,7 @@ namespace Swo\CommonsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PhoneFormType extends AbstractType
 {
@@ -20,12 +20,7 @@ class PhoneFormType extends AbstractType
             ->add('type');
     }
 
-    public function getName()
-    {
-        return 'swo_commons_phoneformtype';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Swo\CommonsBundle\Entity\Phone',

--- a/src/Swo/CommonsBundle/Form/Type/PhoneFormType.php
+++ b/src/Swo/CommonsBundle/Form/Type/PhoneFormType.php
@@ -24,7 +24,6 @@ class PhoneFormType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Swo\CommonsBundle\Entity\Phone',
-            'cascade_validation' => true,
             'translation_domain' => 'SwoCommonsBundle'
         ));
     }

--- a/src/Swo/CommonsBundle/Resources/config/forms.yml
+++ b/src/Swo/CommonsBundle/Resources/config/forms.yml
@@ -4,9 +4,9 @@ services:
     swo_commons.form_type.address:
             class: Swo\CommonsBundle\Form\Type\AddressFormType
             tags:
-                - { name: form.type, alias: swo_commons_addressformtype }
+                - { name: form.type }
 
     swo_commons.form_type.phone:
                 class: Swo\CommonsBundle\Form\Type\PhoneFormType
                 tags:
-                    - { name: form.type, alias: swo_commons_phoneformtype }
+                    - { name: form.type }


### PR DESCRIPTION
Die deprecated Warnungen aus dem Dime Repo hab ich entfernt, so dass man einfacher auf Symfony 3+ upgraden kann. Was noch fehlt sind die Money Bundles, die nicht mehr kompatibel sind. Leider kann man die nicht einfach upgraden, wahrscheinlich muss man sie ersetzen. Ich habe dies versucht, aber leider war es nicht so einfach, da diese in die SWO Organisation geklont wurden und nicht kompatible Changes mit dem originalen Repo gemacht wurden. Ich wollte dies in meinen letzten Tagen auch nicht mehr machen, da die Testabdeckung für die Dinge wie das Moneybundle nicht gut genug sind und ich dann allenfalls ein kaputtes Dime hinterlassen würde. Man würde zwar finden, wenn der Code nicht mehr läuft (falsche Codeaufrufe, Signaturen oder Imports), aber nicht, wenn er falsch läuft bzw. die Ausgaben nicht stimmen.

Darum schlage ich vor, vorerst einfach mal die Deprecated Warning Changes in den Master zu mergen. Diese sollten eigentlich keine Probleme machen.