### PR TITLE
reload activites for each project in timetrack

### DIFF
--- a/src/Dime/FrontendBundle/Resources/public/lib/src/component/overview/child/timeslice_overview_component.dart
+++ b/src/Dime/FrontendBundle/Resources/public/lib/src/component/overview/child/timeslice_overview_component.dart
@@ -114,14 +114,7 @@ class TimesliceOverviewComponent extends EditableOverview<Timeslice> implements 
       this.updateChosenSetting('project');
       this.timetrackService.projectSelect.add(proj);
       _projectChange.add(proj);
-
-      // select the same activity if also it exists in new project
-      try {
-        this.selectedActivity = activities
-            .singleWhere((Activity a) => a.alias == this.settingselectedActivity.value && a.project.id == this.selectedProject.id);
-      } catch (e) {
-        this.selectedActivity = null;
-      }
+      this.updateActivitiesList();
     }
   }
 
@@ -372,7 +365,6 @@ class TimesliceOverviewComponent extends EditableOverview<Timeslice> implements 
 
   Future load() async {
     await this.statusservice.run(() async {
-      this.activities = await this.store.list(Activity);
       this.employees = await this.store.list(Employee, params: {"enabled": 1});
       this.employee = this.context.employee;
       List<Project> projects = await this.store.list(Project);
@@ -393,6 +385,16 @@ class TimesliceOverviewComponent extends EditableOverview<Timeslice> implements 
       } catch (e) {
         this.settingselectedActivity = await settingsManager.createSetting('/usr/timeslice', 'chosenActivity', '');
       }
+
+      await this.updateActivitiesList();
+      this.handleDates();
+    });
+  }
+
+  Future updateActivitiesList() async {
+    await this.statusservice.run(() async {
+      this.activities = await this.store.list(Activity, params: {'project': this.selectedProject.id});
+
       try {
         this.selectedActivity = this
             .activities
@@ -400,8 +402,6 @@ class TimesliceOverviewComponent extends EditableOverview<Timeslice> implements 
       } catch (e) {
         this.selectedActivity = null;
       }
-
-      this.handleDates();
     });
   }
 

--- a/src/Dime/FrontendBundle/Resources/public/lib/src/component/overview/child/timeslice_overview_component.html
+++ b/src/Dime/FrontendBundle/Resources/public/lib/src/component/overview/child/timeslice_overview_component.html
@@ -37,7 +37,7 @@
 </table>
 <div class="DimeControlButtons container-inline">
     <div class="row form-inline">
-        <div class="col-md-4">
+        <div class="col-md-3">
             <label>Datum</label>
             <date-input withButtons [(ngModel)]="newEntryDate">
               <button class="btn" [class.btn-default]="!updateNewEntryDate" [class.btn-primary]="updateNewEntryDate"

--- a/src/Dime/FrontendBundle/Resources/public/lib/src/component/select/activity_select_component.dart
+++ b/src/Dime/FrontendBundle/Resources/public/lib/src/component/select/activity_select_component.dart
@@ -51,19 +51,19 @@ class ActivitySelectComponent extends EntitySelect<Activity> implements OnChange
   }
 
   void _onChange(List<Activity> oldList, List<Activity> newList) {
-    if (this.entities != null && this.entities.isEmpty && newList != null && newList.isNotEmpty) {
+    if (newList != null && newList.isNotEmpty) {
       reload();
     }
   }
 
   @override
   Future reload() async {
-    await this.statusservice.run(() async {
-      if (this.parentActivities != null) {
-        this.entities = this.parentActivities;
-      } else {
+    if (this.parentActivities != null) {
+      this.entities = this.parentActivities;
+    } else {
+      await this.statusservice.run(() async {
         this.entities = await this.store.list(Activity, params: {'project': this.projectId});
-      }
-    });
+      });
+    }
   }
 }


### PR DESCRIPTION
context: if we fetch all activities at once, doctrine will load their associated timeslices even we excluded it in the JMS annotations. It is possible not possible in our case to make the Activity entity unaware of its relation to the timeslices nor to rewrite the all method to prefetch the relation because Doctrine and JMS would still do the same stuff as before.